### PR TITLE
Behaviour: move behaviour letters into email templates, update setting names

### DIFF
--- a/modules/Activities/activities_manage_add.php
+++ b/modules/Activities/activities_manage_add.php
@@ -19,6 +19,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use Gibbon\Forms\Form;
 use Gibbon\Forms\DatabaseFormFactory;
+use Gibbon\Domain\Activities\ActivityGateway;
+use Gibbon\Domain\System\SettingGateway;
 
 //Module includes
 require_once __DIR__ . '/moduleFunctions.php';
@@ -38,201 +40,300 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     }
     $page->return->setEditLink($editLink);
 
-    if ($_GET['search'] != '' || $_GET['gibbonSchoolYearTermID'] != '') {
-        echo "<div class='linkTop'>";
-        echo "<a href='".$session->get('absoluteURL').'/index.php?q=/modules/Activities/activities_manage.php&search='.$_GET['search']."&gibbonSchoolYearTermID=".$_GET['gibbonSchoolYearTermID']."'>".__('Back to Search Results').'</a>';
-        echo '</div>';
-	}
+    $search = $_GET['search'] ?? null;
+    
+    $activityGateway = $container->get(ActivityGateway::class);
+    $settingGateway = $container->get(SettingGateway::class);
 
-	$search = $_GET['search'] ?? null;
+    $form = Form::create('activity', $session->get('absoluteURL').'/modules/'.$session->get('module').'/activities_manage_addProcess.php?search='.$search.'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']);
+    $form->setFactory(DatabaseFormFactory::create($pdo));
 
-	$form = Form::create('activity', $session->get('absoluteURL').'/modules/'.$session->get('module').'/activities_manage_addProcess.php?search='.$search.'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID']);
-	$form->setFactory(DatabaseFormFactory::create($pdo));
+    if (!empty($_GET['search']) || !empty($_GET['gibbonSchoolYearTermID'])) {
+        $form->addHeaderAction('back', __('Back to Results'))
+            ->setURL('/modules/Activities/activities_manage.php')
+            ->addParam('search', $_GET['search'])
+            ->addParam('gibbonSchoolYearTermID', $_GET['gibbonSchoolYearTermID']);
+    }
 
-	$form->addHiddenValue('address', $session->get('address'));
+    $form->addHiddenValue('address', $session->get('address'));
 
-	$form->addRow()->addHeading(__('Basic Information'));
+    $form->addRow()->addHeading(__('Basic Information'));
 
-	$row = $form->addRow();
+    $row = $form->addRow();
         $row->addLabel('name', __('Name'));
-		$row->addTextField('name')->required()->maxLength(40);
+        $row->addTextField('name')
+            ->required()
+            ->maxLength(40);
 
-	$row = $form->addRow();
+    $row = $form->addRow();
         $row->addLabel('provider', __('Provider'));
-        $row->addSelect('provider')->required()->fromArray(array('School' => $session->get('organisationNameShort'), 'External' => __('External')));
+        $row->addSelect('provider')
+            ->required()
+            ->fromArray([
+                'School'    => $session->get('organisationNameShort'),
+                'External'  => __('External')
+            ]);
+    
+    $activityTypes = $settingGateway->getSettingByScope('Activities', 'activityTypes');
+    if (!empty($activityTypes)) {
+        $row = $form->addRow();
+            $row->addLabel('type', __('Type'));
+            $row->addSelect('type')
+                ->fromString($activityTypes)
+                ->placeholder();
+    }
 
-	$activityTypes = getSettingByScope($connection2, 'Activities', 'activityTypes');
-	if (!empty($activityTypes)) {
-		$row = $form->addRow();
-        	$row->addLabel('type', __('Type'));
-        	$row->addSelect('type')->fromString($activityTypes)->placeholder();
-	}
-
-	$row = $form->addRow();
+    $row = $form->addRow();
         $row->addLabel('active', __('Active'));
-		$row->addYesNo('active')->required();
+        $row->addYesNo('active')->required();
 
-	$row = $form->addRow();
+    $row = $form->addRow();
         $row->addLabel('registration', __('Registration'))->description(__('Assuming system-wide registration is open, should this activity be open for registration?'));
-		$row->addYesNo('registration')->required();
+        $row->addYesNo('registration')->required();
 
-	$dateType = getSettingByScope($connection2, 'Activities', 'dateType');
-	$form->addHiddenValue('dateType', $dateType);
-	if ($dateType != 'Date') {
-		$row = $form->addRow();
+    $dateType = $settingGateway->getSettingByScope('Activities', 'dateType');
+    $form->addHiddenValue('dateType', $dateType);
+    if ($dateType != 'Date') {
+        $row = $form->addRow();
             $row->addLabel('gibbonSchoolYearTermIDList', __('Terms'))->description(__('Terms in which the activity will run.'));
             $row->addCheckboxSchoolYearTerm('gibbonSchoolYearTermIDList', $session->get('gibbonSchoolYearID'))->checkAll();
-	} else {
-		$listingStart = $listingEnd = $programStart = $programEnd = new DateTime();
+    } else {
+        $listingStart = $listingEnd = $programStart = $programEnd = new DateTime();
 
-		$data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'today' => date('Y-m-d'));
-		$sql = "SELECT * FROM gibbonSchoolYearTerm WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND lastDay>=:today ORDER BY sequenceNumber";
-		$result = $pdo->executeQuery($data, $sql);
-		if ($result->rowCount() > 0) {
-			if ($currentTerm = $result->fetch()) {
-				$listingStart = (new DateTime($currentTerm['lastDay']))->modify('-2 weeks');
-			}
+        $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'today' => date('Y-m-d'));
+        $sql = "SELECT * FROM gibbonSchoolYearTerm WHERE gibbonSchoolYearID=:gibbonSchoolYearID AND lastDay>=:today ORDER BY sequenceNumber";
+        $result = $pdo->executeQuery($data, $sql);
+        if ($result->rowCount() > 0) {
+            if ($currentTerm = $result->fetch()) {
+                $listingStart = (new DateTime($currentTerm['lastDay']))->modify('-2 weeks');
+            }
 
-			if ($nextTerm = $result->fetch()) {
-				$listingEnd = (new DateTime($nextTerm['firstDay']))->modify('+2 weeks');
-				$programStart = new DateTime($nextTerm['firstDay']);
-				$programEnd = new DateTime($nextTerm['lastDay']);
-			}
-		}
+            if ($nextTerm = $result->fetch()) {
+                $listingEnd = (new DateTime($nextTerm['firstDay']))->modify('+2 weeks');
+                $programStart = new DateTime($nextTerm['firstDay']);
+                $programEnd = new DateTime($nextTerm['lastDay']);
+            }
+        }
 
-		$row = $form->addRow();
-        	$row->addLabel('listingStart', __('Listing Start Date'))->description(__('Default: 2 weeks before the end of the current term.'));
-			$row->addDate('listingStart')->required()->setValue($listingStart->format($session->get('i18n')['dateFormatPHP']));
+        $dateFormatPHP = $session->get('i18n')['dateFormatPHP'];
 
-		$row = $form->addRow();
-        	$row->addLabel('listingEnd', __('Listing End Date'))->description(__('Default: 2 weeks after the start of next term.'));
-			$row->addDate('listingEnd')->required()->setValue($listingEnd->format($session->get('i18n')['dateFormatPHP']));
+        $row = $form->addRow();
+            $row->addLabel('listingStart', __('Listing Start Date'))->description(__('Default: 2 weeks before the end of the current term.'));
+            $row->addDate('listingStart')
+                ->required()
+                ->setValue($listingStart->format($dateFormatPHP));
 
-		$row = $form->addRow();
-        	$row->addLabel('programStart', __('Program Start Date'))->description(__('Default: first day of next term.'));
-			$row->addDate('programStart')->required()->setValue($programStart->format($session->get('i18n')['dateFormatPHP']));
+        $row = $form->addRow();
+            $row->addLabel('listingEnd', __('Listing End Date'))->description(__('Default: 2 weeks after the start of next term.'));
+            $row->addDate('listingEnd')
+                ->required()
+                ->setValue($listingEnd->format($dateFormatPHP));
 
-		$row = $form->addRow();
-        	$row->addLabel('programEnd', __('Program End Date'))->description(__('Default: last day of the next term.'));
-			$row->addDate('programEnd')->required()->setValue($programEnd->format($session->get('i18n')['dateFormatPHP']));
-	}
+        $row = $form->addRow();
+            $row->addLabel('programStart', __('Program Start Date'))->description(__('Default: first day of next term.'));
+            $row->addDate('programStart')
+                ->required()
+                ->setValue($programStart->format($dateFormatPHP));
 
-	$row = $form->addRow();
+        $row = $form->addRow();
+            $row->addLabel('programEnd', __('Program End Date'))->description(__('Default: last day of the next term.'));
+            $row->addDate('programEnd')
+                ->required()
+                ->setValue($programEnd->format($dateFormatPHP));
+    }
+
+    $row = $form->addRow();
         $row->addLabel('gibbonYearGroupIDList', __('Year Groups'));
-        $row->addCheckboxYearGroup('gibbonYearGroupIDList')->checkAll()->addCheckAllNone();
+        $row->addCheckboxYearGroup('gibbonYearGroupIDList')
+            ->checkAll()
+            ->addCheckAllNone();
 
-	$row = $form->addRow();
+    $row = $form->addRow();
         $row->addLabel('maxParticipants', __('Max Participants'));
-		$row->addNumber('maxParticipants')->required()->maxLength(4)->setValue('0');
+        $row->addNumber('maxParticipants')
+            ->required()
+            ->maxLength(4)
+            ->setValue('0');
 
-	$column = $form->addRow()->addColumn();
+    $column = $form->addRow()->addColumn();
         $column->addLabel('description', __('Description'));
-        $column->addEditor('description', $guid)->setRows(10)->showMedia();
+        $column->addEditor('description', $guid)
+            ->setRows(10)
+            ->showMedia();
 
-	$payment = getSettingByScope($connection2, 'Activities', 'payment');
-	if ($payment != 'None' && $payment != 'Single') {
-		$form->addRow()->addHeading(__('Cost'));
+    $payment = $settingGateway->getSettingByScope('Activities', 'payment');
+    if ($payment != 'None' && $payment != 'Single') {
+        $form->addRow()->addHeading(__('Cost'));
 
-		$row = $form->addRow();
-        	$row->addLabel('payment', __('Cost'));
-			$row->addCurrency('payment')->required()->maxLength(9)->setValue('0.00');
+        $row = $form->addRow();
+            $row->addLabel('payment', __('Cost'));
+            $row->addCurrency('payment')
+                ->required()
+                ->maxLength(9)
+                ->setValue('0.00');
 
-		$costTypes = array(
-			'Entire Programme' => __('Entire Programme'),
-			'Per Session'      => __('Per Session'),
-			'Per Week'         => __('Per Week'),
-			'Per Term'         => __('Per Term'),
-		);
+        $row = $form->addRow();
+            $row->addLabel('paymentType', __('Cost Type'));
+            $row->addSelect('paymentType')
+                ->required()
+                ->fromArray([
+                    'Entire Programme' => __('Entire Programme'),
+                    'Per Session'      => __('Per Session'),
+                    'Per Week'         => __('Per Week'),
+                    'Per Term'         => __('Per Term'),
+                ]);
 
-		$row = $form->addRow();
-        	$row->addLabel('paymentType', __('Cost Type'));
-			$row->addSelect('paymentType')->required()->fromArray($costTypes);
+        $row = $form->addRow();
+            $row->addLabel('paymentFirmness', __('Cost Status'));
+            $row->addSelect('paymentFirmness')
+                ->required()
+                ->fromArray([
+                    'Finalised' => __('Finalised'),
+                    'Estimated' => __('Estimated'),
+                ]);
+    }
 
-		$costStatuses = array(
-            'Finalised' => __('Finalised'),
-            'Estimated' => __('Estimated'),
-		);
+    $form->addRow()->addHeading(__('Time Slots'));
 
-		$row = $form->addRow();
-        	$row->addLabel('paymentFirmness', __('Cost Status'));
-        	$row->addSelect('paymentFirmness')->required()->fromArray($costStatuses);
-	}
+    //Block template
+    $sqlWeekdays = "SELECT gibbonDaysOfWeekID as value, name FROM gibbonDaysOfWeek ORDER BY sequenceNumber";
 
-	$form->addRow()->addHeading(__('Time Slots'));
+    $slotBlock = $form->getFactory()->createTable()->setClass('blank');
+        $row = $slotBlock->addRow();
+            $row->addLabel('gibbonDaysOfWeekID', __('Slot Day'));
+            $row->addSelect('gibbonDaysOfWeekID')
+                ->fromQuery($pdo, $sqlWeekdays)
+                ->placeholder()
+                ->addClass('floatLeft');
 
-	$sqlWeekdays = "SELECT gibbonDaysOfWeekID as value, name FROM gibbonDaysOfWeek ORDER BY sequenceNumber";
-	$sqlSpaces = "SELECT gibbonSpaceID as value, name FROM gibbonSpace ORDER BY name";
-	$locations = array(
-		'Internal' => __('Internal'),
-		'External' => __('External'),
-	);
+        $row = $slotBlock->addRow();
+            $row->addLabel('timeStart', __('Slot Start Time'));
+            $row->addTime('timeStart');
+        
+            $row->addLabel('timeEnd', __('Slot End Time'));
+            $row->addTime('timeEnd')
+                ->chainedTo('timeStart');
 
-    for ($i = 1; $i <= 2; ++$i) {
-		$form->addRow()->addSubheading(__('Slot').' '.$i)->addClass("slotRow{$i}");
+        $row = $slotBlock->addRow();
+            $row->addLabel('location', __('Location'));
+            $row->addRadio('location')
+                ->inline()
+                ->alignLeft()
+                ->fromArray([
+                    'Internal' => __('Internal'),
+                    'External' => __('External')
+                ]);
 
-		$row = $form->addRow()->addClass("slotRow{$i}");
-        	$row->addLabel("gibbonDaysOfWeekID{$i}", sprintf(__('Slot %1$s Day'), $i));
-			$row->addSelect("gibbonDaysOfWeekID{$i}")->fromQuery($pdo, $sqlWeekdays)->placeholder();
+        $row = $slotBlock->addRow()->addClass('hideShow');
+            $row->addSelectSpace('gibbonSpaceID')
+                ->placeholder()
+                ->addClass('sm:max-w-full w-full');
 
-		$row = $form->addRow()->addClass("slotRow{$i}");
-            $row->addLabel('timeStart'.$i, sprintf(__('Slot %1$s Start Time'), $i));
-            $row->addTime('timeStart'.$i);
+        $row = $slotBlock->addRow()->addClass('showHide');
+            $row->addTextField("locationExternal")
+                ->maxLength(50)
+                ->addClass('sm:max-w-full w-full');
 
-		$row = $form->addRow()->addClass("slotRow{$i}");
-			$row->addLabel("timeEnd{$i}", sprintf(__('Slot %1$s End Time'), $i));
-			$row->addTime("timeEnd{$i}")->chainedTo('timeStart'.$i);
+    //Tool Button
+    $addBlockButton = $form->getFactory()
+        ->createButton(__('Add Time Slot'))
+        ->addClass('addBlock');
 
-		$row = $form->addRow()->addClass("slotRow{$i}");
-            $row->addLabel("slot{$i}Location", sprintf(__('Slot %1$s Location'), $i));
-			$row->addRadio("slot{$i}Location")->fromArray($locations)->inline();
+    //Custom Blocks
+    $row = $form->addRow();
+        $slotBlocks = $row->addCustomBlocks('timeSlots', $session)
+            ->fromTemplate($slotBlock)
+            ->settings([
+                'placeholder' => __('Time Slots will appear here...'),
+                'sortable' => true,
+            ])
+            ->addToolInput($addBlockButton);
 
-		$form->toggleVisibilityByClass("slotRow{$i}Internal")->onRadio("slot{$i}Location")->when('Internal');
-		$row = $form->addRow()->addClass("slotRow{$i}Internal");
-			$row->addSelect("gibbonSpaceID{$i}")->fromQuery($pdo, $sqlSpaces)->placeholder();
+    $slotBlocks->addPredefinedBlock("Add Time Slot", ['location' => 'Internal']);
 
-		$form->toggleVisibilityByClass("slotRow{$i}External")->onRadio("slot{$i}Location")->when('External');
-		$row = $form->addRow()->addClass("slotRow{$i}External");
-			$row->addTextField("location{$i}External")->maxLength(50);
+    $form->addRow()->addHeading(__('Staff'));
 
-		if ($i == 1) {
-			$form->toggleVisibilityByClass("slot{$i}ButtonRow")->onRadio("slot{$i}Location")->when(array('Internal', 'External'));
-			$row = $form->addRow()->addClass("slotRow{$i} slot{$i}ButtonRow");
-			$row->addButton(__('Add Another Slot'))
-				->onClick("$('.slotRow2').show();$('.slot1ButtonRow').hide();")
-				->addClass('right buttonAsLink');
-		}
-	}
+    $row = $form->addRow();
+        $row->addLabel('staff', __('Staff'));
+        $row->addSelectUsers('staff', $session->get('gibbonSchoolYearID'), ['includeStaff' => true])->selectMultiple();
 
+    $row = $form->addRow();
+        $row->addLabel('role', 'Role');
+        $row->addSelect('role')
+            ->fromArray([
+                'Organiser' => __('Organiser'),
+                'Coach'     => __('Coach'),
+                'Assistant' => __('Assistant'),
+                'Other'     => __('Other'), 
+            ]);
 
-	$form->addRow()->addHeading(__('Staff'));
+    $row = $form->addRow();
+        $row->addFooter();
+        $row->addSubmit();
 
-	$row = $form->addRow();
-		$row->addLabel('staff', __('Staff'));
-		$row->addSelectUsers('staff', $session->get('gibbonSchoolYearID'), array('includeStaff' => true))->selectMultiple();
+    echo $form->getOutput();
+    ?>
 
-	$staffRoles = array(
-		'Organiser' => __('Organiser'),
-		'Coach'     => __('Coach'),
-		'Assistant' => __('Assistant'),
-		'Other'     => __('Other'),
-	);
+    <script type="text/javascript">
+        //All of this javascript is due to limitations of CustomBlocks. If these limitaions are fixed in the future, the corresponding block of code should be removed.
+        var radio = 'input[type="radio"][name$="[location]"]';
 
-	$row = $form->addRow();
-		$row->addLabel('role', 'Role');
-		$row->addSelect('role')->fromArray($staffRoles);
+        function locationSwap() {
+            var block = $(this).closest('tbody');
+            if ($(this).prop('id').startsWith('location0')) {
+                block.find('.showHide').hide();
+                block.find('.hideShow').show();
+            } else {
+                block.find('.showHide').show();
+                block.find('.hideShow').hide();
+            }
+        }
 
-	$row = $form->addRow();
-		$row->addFooter();
-		$row->addSubmit();
+        var time = 'input[id^="time"]';
+        function setTimepicker(input) {
+            input.removeClass('hasTimepicker').timepicker({
+                    'scrollDefault': 'now',
+                    'timeFormat': 'H:i',
+                    'minTime': '00:00',
+                    'maxTime': '23:59',
+                    onSelect: function(){$(this).blur();},
+                    onClose: function(){$(this).change();}
+                });
+        }
 
-	echo $form->getOutput();
-	?>
+        $(document).ready(function(){
+            //This is to ensure that loaded blocks have the correct state.
+            $(radio + ':checked').each(locationSwap);
 
-	<script type="text/javascript">
-	$(document).ready(function(){
-		$('.slotRow2').hide();
-	});
-	</script>
+            //This is to ensure that loaded blocks have timepickers
+            $(time).each(function() {
+                setTimepicker($(this));
+            });
 
-	<?php
+            //This is needed to ensure that loaded timeEnds are properly chained to loaded timeStarts
+            $('input[id^=timeEnd]').each(function() {
+                var timeStart = $('#' + $(this).prop('id').replace('End', 'Start'));
+                $(this).timepicker('option', {'minTime': timeStart.val(), 'timeFormat': 'H:i', 'showDuration': true});
+            });
+        });
+
+        //This supplements triggers for the Internal and External Locations
+        $(document).on('change', radio, locationSwap);
+
+        //This is needed to make chaining Times work with Custom Blocks
+        $(document).on('changeTime', 'input[id^=timeStart]', function() {
+            var timeEnd = $('#' + $(this).prop('id').replace('Start', 'End'));
+            if (timeEnd.val() == "" || $(this).val() > timeEnd.val()) {
+                timeEnd.val($(this).val());
+            }
+            timeEnd.timepicker('option', {'minTime': $(this).val(), 'timeFormat': 'H:i', 'showDuration': true});
+        });
+
+        //This is needed to make Time inputs have time pickers.
+        $(document).on('click', '.addBlock', function () {
+            setTimepicker($(time));
+        });
+    </script>
+
+    <?php
 }

--- a/modules/Activities/activities_manage_addProcess.php
+++ b/modules/Activities/activities_manage_addProcess.php
@@ -17,12 +17,15 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
+use Gibbon\Domain\Activities\ActivityGateway;
+use Gibbon\Domain\Activities\ActivitySlotGateway;
+use Gibbon\Domain\Activities\ActivityStaffGateway;
+use Gibbon\Domain\System\SettingGateway;
 use Gibbon\Services\Format;
 
 include '../../gibbon.php';
 
-$address = $_POST['address'] ?? '';
-$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($address).'/activities_manage_add.php&search='.$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID'];
+$URL = $session->get('absoluteURL').'/index.php?q=/modules/'.getModuleName($_POST['address']).'/activities_manage_add.php&search='.$_GET['search'].'&gibbonSchoolYearTermID='.$_GET['gibbonSchoolYearTermID'];
 
 if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_manage_add.php') == false) {
     $URL .= '&return=error0';
@@ -38,16 +41,20 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
         $gibbonSchoolYearTermIDList =  $_POST['gibbonSchoolYearTermIDList'] ?? [];
         $gibbonSchoolYearTermIDList = implode(',', $gibbonSchoolYearTermIDList);
     } elseif ($dateType == 'Date') {
-        $listingStart = !empty($_POST['listingStart']) ? Format::dateConvert($_POST['listingStart']) : null;
-        $listingEnd = !empty($_POST['listingEnd']) ? Format::dateConvert($_POST['listingEnd']) : null;
-        $programStart = !empty($_POST['programStart']) ? Format::dateConvert($_POST['programStart']) : null;
-        $programEnd = !empty($_POST['programEnd']) ? Format::dateConvert($_POST['programEnd']) : null;
+            $listingStart = Format::dateConvert($_POST['listingStart'] ?? '');
+            $listingEnd = Format::dateConvert($_POST['listingEnd'] ?? '');
+            $programStart = Format::dateConvert($_POST['programStart'] ?? '');
+            $programEnd = Format::dateConvert($_POST['programEnd'] ?? '');
     }
-    $gibbonYearGroupIDList = $_POST['gibbonYearGroupIDList'] ?? array();
-    $gibbonYearGroupIDList = implode(',', $gibbonYearGroupIDList);
 
+    $gibbonYearGroupIDList = $_POST['gibbonYearGroupIDList'] ?? [];
+    $gibbonYearGroupIDList = implode(',', $gibbonYearGroupIDList);
+    
     $maxParticipants = $_POST['maxParticipants'] ?? '';
-    if (getSettingByScope($connection2, 'Activities', 'payment') == 'None' or getSettingByScope($connection2, 'Activities', 'payment') == 'Single') {
+    
+    $settingGateway = $container->get(SettingGateway::class);
+    $paymentMethod = $settingGateway->getSettingByScope('Activities', 'payment');
+    if ($paymentMethod == 'None' || $paymentMethod == 'Single') {
         $paymentOn = false;
         $payment = null;
         $paymentType = null;
@@ -60,63 +67,81 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
     }
     $description = $_POST['description'] ?? '';
 
-    if ($dateType == '' or $name == '' or $provider == '' or $active == '' or $registration == '' or $maxParticipants == '' or ($paymentOn and ($payment == '' or $paymentType == '' or $paymentFirmness == '')) or ($dateType == 'Date' and ($listingStart == '' or $listingEnd == '' or $programStart == '' or $programEnd == ''))) {
-        $URL .= '&return=error1';
+    if ($dateType == '' || $name == '' || $provider == '' || $active == '' || $registration == '' || $maxParticipants == '' || ($paymentOn && ($payment == '' || $paymentType == '' || $paymentFirmness == '')) || ($dateType == 'Date' && ($listingStart == '' || $listingEnd == '' || $programStart == '' || $programEnd == ''))) {
+           $URL .= '&return=error1';
         header("Location: {$URL}");
     } else {
         //Write to database
-        $type = '';
-        if (isset($_POST['type'])) {
-            $type = $_POST['type'];
+        $activityGateway = $container->get(ActivityGateway::class);
+        
+        $type = $_POST['type'] ?? '';
+
+        $data = [
+            'gibbonSchoolYearID'    => $session->get('gibbonSchoolYearID'),
+            'name'                  => $name,
+            'provider'              => $provider,
+            'type'                  => $type,
+            'active'                => $active,
+            'registration'          => $registration,
+            'gibbonYearGroupIDList' => $gibbonYearGroupIDList,
+            'maxParticipants'       => $maxParticipants,
+            'payment'               => $payment,
+            'paymentType'           => $paymentType,
+            'paymentFirmness'       => $paymentFirmness,
+            'description'           => $description
+        ];
+
+        if ($dateType == 'Date') {
+            $data['gibbonSchoolYearTermIDList'] = '';
+            $data['listingStart'] = $listingStart;
+            $data['listingEnd'] = $listingEnd;
+            $data['programStart'] = $programStart;
+            $data['programEnd'] = $programEnd;
+        } else {
+            $data['gibbonSchoolYearTermIDList'] = $gibbonSchoolYearTermIDList;
+            $data['listingStart'] = null;
+            $data['listingEnd'] = null;
+            $data['programStart'] = null;
+            $data['programEnd'] = null;
         }
 
-        try {
-            if ($dateType == 'Date') {
-                $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'name' => $name, 'provider' => $provider, 'type' => $type, 'active' => $active, 'registration' => $registration, 'listingStart' => $listingStart, 'listingEnd' => $listingEnd, 'programStart' => $programStart, 'programEnd' => $programEnd, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList, 'maxParticipants' => $maxParticipants, 'payment' => $payment, 'paymentType' => $paymentType, 'paymentFirmness' => $paymentFirmness, 'description' => $description);
-                $sql = "INSERT INTO gibbonActivity SET gibbonSchoolYearID=:gibbonSchoolYearID, name=:name, provider=:provider, type=:type, active=:active, registration=:registration, gibbonSchoolYearTermIDList='', listingStart=:listingStart, listingEnd=:listingEnd, programStart=:programStart, programEnd=:programEnd, gibbonYearGroupIDList=:gibbonYearGroupIDList, maxParticipants=:maxParticipants, payment=:payment, paymentType=:paymentType, paymentFirmness=:paymentFirmness, description=:description";
-            } else {
-                $data = array('gibbonSchoolYearID' => $session->get('gibbonSchoolYearID'), 'name' => $name, 'provider' => $provider, 'type' => $type, 'active' => $active, 'registration' => $registration, 'gibbonSchoolYearTermIDList' => $gibbonSchoolYearTermIDList, 'gibbonYearGroupIDList' => $gibbonYearGroupIDList, 'maxParticipants' => $maxParticipants, 'payment' => $payment, 'paymentType' => $paymentType, 'paymentFirmness' => $paymentFirmness, 'description' => $description);
-                $sql = 'INSERT INTO gibbonActivity SET gibbonSchoolYearID=:gibbonSchoolYearID, name=:name, provider=:provider, type=:type, active=:active, registration=:registration, gibbonSchoolYearTermIDList=:gibbonSchoolYearTermIDList, listingStart=NULL, listingEnd=NULL, programStart=NULL, programEnd=NULL, gibbonYearGroupIDList=:gibbonYearGroupIDList, maxParticipants=:maxParticipants, payment=:payment, paymentType=:paymentType, paymentFirmness=:paymentFirmness, description=:description';
-            }
-            $result = $connection2->prepare($sql);
-            $result->execute($data);
-        } catch (PDOException $e) {
+        $gibbonActivityID = $activityGateway->insert($data);
+
+        if (!$gibbonActivityID) {
             $URL .= '&return=error2';
             header("Location: {$URL}");
             exit();
         }
 
-        //Last insert ID
-        $AI = str_pad($connection2->lastInsertID(), 14, '0', STR_PAD_LEFT);
+        $activitySlotGateway = $container->get(ActivitySlotGateway::class);
 
-        //Scan through slots
-        $partialFail = false;
-        for ($i = 1; $i < 3; ++$i) {
-            $gibbonDaysOfWeekID = $_POST["gibbonDaysOfWeekID$i"] ?? '';
-            $timeStart = $_POST["timeStart$i"] ?? '';
-            $timeEnd = $_POST["timeEnd$i"] ?? '';
-            $type = 'Internal';
-            if (isset($_POST['slot'.$i.'Location'])) {
-                $type = $_POST['slot'.$i.'Location'];
+        $timeSlotOrder = $_POST['order'] ?? [];
+        foreach ($timeSlotOrder as $order) {
+            $slot = $_POST['timeSlots'][$order];
+
+            if (empty($slot['gibbonDaysOfWeekID']) || empty($slot['timeStart']) || empty('timeEnd')) {
+                continue;
             }
-            $gibbonSpaceID = null;
+
+            //If start is after end, swap times.
+            if ($slot['timeStart'] > $slot['timeEnd']) {
+                $temp = $slot['timeStart'];
+                $slot['timeStart'] = $slot['timeEnd'];
+                $slot['timeEnd'] = $temp;
+            }
+
+            $slot['gibbonActivityID'] = $gibbonActivityID;
+
+            $type = $slot['location'] ?? 'Internal';
             if ($type == 'Internal') {
-                $gibbonSpaceID = $_POST["gibbonSpaceID$i"] ?? null;
-                $locationExternal = '';
+                $slot['locationExternal'] = '';
             } else {
-                $locationExternal = $_POST['location'.$i.'External'] ?? '';
+                $slot['gibbonSpaceID'] = null;
             }
 
-            if ($gibbonDaysOfWeekID != '' and $timeStart != '' and $timeEnd != '') {
-                try {
-                    $data = array('AI' => $AI, 'gibbonDaysOfWeekID' => $gibbonDaysOfWeekID, 'timeStart' => $timeStart, 'timeEnd' => $timeEnd, 'gibbonSpaceID' => $gibbonSpaceID, 'locationExternal' => $locationExternal);
-                    $sql = 'INSERT INTO gibbonActivitySlot SET gibbonActivityID=:AI, gibbonDaysOfWeekID=:gibbonDaysOfWeekID, timeStart=:timeStart, timeEnd=:timeEnd, gibbonSpaceID=:gibbonSpaceID, locationExternal=:locationExternal';
-                    $result = $connection2->prepare($sql);
-                    $result->execute($data);
-                } catch (PDOException $e) {
-                    $partialFail = true;
-                }
-            }
+            unset($slot['location']);
+
+            $activitySlotGateway->insert($slot);
         }
 
         // Scan through staff
@@ -125,41 +150,21 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
 
         // make sure that staff is an array
         if (!is_array($staff)) {
-            $staff = [(string) $staff];
+            $staff = [strval($staff)];
         }
 
-        if (count($staff) > 0) {
-            foreach ($staff as $t) {
-                //Check to see if person is already registered in this activity
-                try {
-                    $dataGuest = array('gibbonPersonID' => $t, 'gibbonActivityID' => $AI);
-                    $sqlGuest = 'SELECT * FROM gibbonActivityStaff WHERE gibbonPersonID=:gibbonPersonID AND gibbonActivityID=:gibbonActivityID';
-                    $resultGuest = $connection2->prepare($sqlGuest);
-                    $resultGuest->execute($dataGuest);
-                } catch (PDOException $e) {
-                    $partialFail = true;
-                }
-
-                if ($resultGuest->rowCount() == 0) {
-                    try {
-                        $data = array('gibbonPersonID' => $t, 'gibbonActivityID' => $AI, 'role' => $role);
-                        $sql = 'INSERT INTO gibbonActivityStaff SET gibbonPersonID=:gibbonPersonID, gibbonActivityID=:gibbonActivityID, role=:role';
-                        $result = $connection2->prepare($sql);
-                        $result->execute($data);
-                    } catch (PDOException $e) {
-                        echo "here<div class='error'>".$e->getMessage().'</div>';
-                        $partialFail = true;
-                    }
-                }
-            }
+        $activityStaffGateway = $container->get(ActivityStaffGateway::class);
+        foreach ($staff as $staffPersonID) {
+            $partialFail |= !$activityStaffGateway->insertActivityStaff($gibbonActivityID, $staffPersonID, $role);
         }
 
-        if ($partialFail == true) {
+        if ($partialFail) {
             $URL .= '&return=warning1';
-            header("Location: {$URL}");
         } else {
-            $URL .= "&return=success0&editID=$AI";
-            header("Location: {$URL}");
+            $URL .= '&return=success0';
         }
+
+        $URL .= '&editID=' . $gibbonActivityID;
+        header("Location: {$URL}");
     }
 }

--- a/modules/Activities/activities_manage_edit.php
+++ b/modules/Activities/activities_manage_edit.php
@@ -248,7 +248,6 @@ if (isActionAccessible($guid, $connection2, '/modules/Activities/activities_mana
             $timeSlots = $activitySlotGateway->selectBy(['gibbonActivityID' => $gibbonActivityID]);
 
             foreach ($timeSlots as $slot) {
-                //Must cast to int for select to work.
                 $slot['location'] = empty($slot['gibbonSpaceID']) ? 'External' : 'Internal';
                 $slotBlocks->addBlock($slot['gibbonActivitySlotID'], $slot);
             }

--- a/modules/Reports/moduleFunctions.php
+++ b/modules/Reports/moduleFunctions.php
@@ -24,7 +24,7 @@ function parseComponent($directoryPath, $filePath, $templateType = 'Additional',
 {
     if (empty($yaml)) $yaml = new Yaml();
 
-    $filename = str_replace($directoryPath.'/', '', $filePath);
+    $filename = str_replace($directoryPath.DIRECTORY_SEPARATOR, '', $filePath);
     $fileContents = file_get_contents($filePath);
 
     // Scan the file for the necessary front matter

--- a/modules/Reports/templates_assets_scanProcess.php
+++ b/modules/Reports/templates_assets_scanProcess.php
@@ -48,7 +48,7 @@ if (isActionAccessible($guid, $connection2, '/modules/Reports/templates_assets.p
 
     $parseAndUpdateComponents = function ($directoryPath, $templateType) use (&$prototypeGateway, &$yaml, &$partialFail, &$count) {
         // Get all twig files in this folder and sub-folders
-        $directoryPath = '/'.trim($directoryPath, '/');
+        $directoryPath = DIRECTORY_SEPARATOR.trim($directoryPath, DIRECTORY_SEPARATOR);
         $directoryFiles = glob($directoryPath.'{,/*,/*/*,/.../*}/*.twig.html', GLOB_BRACE);
 
         foreach ($directoryFiles as $filePath) {

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -66,11 +66,12 @@ class Url extends Uri implements UriInterface
     protected $module;
 
     /**
-     * The route path.
+     * Gibbon's internal route path. Would be non-null if created from methods
+     * like fromRoute, fromModuleRoute. Affects how __toString works.
      *
-     * @var string
+     * @var string|null
      */
-    protected $routePath;
+    protected $routePath = null;
 
     /**
      * Create Uri instance for the root-relative url of the given Gibbon routes.
@@ -162,21 +163,22 @@ class Url extends Uri implements UriInterface
      */
     public function __toString()
     {
-        // Only override rendering if a route pat is set.
+        // Only override rendering if a route path is set.
         // Supposed to only happen if created by the
         // fromRoute() or fromModuleRoute() methods.
         if (isset($this->routePath)) {
             $query = $this->getQueryParams();
             $handler_path = $this->getPath() . '/' . $this->routeHandler;
             $route_target = !empty($this->routePath) ? $this->routePath . '.php' : '';
+            $route_target = !empty($this->module)
+                ? '/modules/' . $this->module . '/' . $route_target
+                : $route_target;
+
             if (!empty($route_target)) {
                 // overwrite "q" in query with module / core route path
-                $query = [
-                    'q' => !empty($this->module)
-                        ? '/modules/' . $this->module . '/' . $route_target
-                        : $route_target,
-                ] + $query;
+                $query = ['q' => $route_target] + $query;
             }
+
             $new = $this
                 ->withPath($handler_path)
                 ->withQueryParams($query);

--- a/src/View/Components/Breadcrumbs.php
+++ b/src/View/Components/Breadcrumbs.php
@@ -19,10 +19,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 namespace Gibbon\View\Components;
 
+use Psr\Http\Message\UriInterface;
+
 /**
  * Breadcrumb trail.
  *
- * @version v17
+ * @version v23
  * @since   v17
  */
 class Breadcrumbs
@@ -48,25 +50,42 @@ class Breadcrumbs
     public function setBaseURL(string $baseURL)
     {
         $this->baseURL = trim($baseURL, '/ ').'/';
-        
         return $this;
     }
 
     /**
      * Add a named route to the trail.
      *
-     * @param string $title   Name to display on this route's link
-     * @param string $route   URL relative to the trail's BaseURL
-     * @param array  $params  Additional URL params to append to the route
+     * @version v23
+     * @since   v17
+     *
+     * @param string              $title   Name to display on this route's link
+     * @param string|UriInterface $route   String URL relative to the trail's BaseURL, or
+     *                                     UriInterface.
+     * @param array               $params  Additional URL params to append to the route.
+     *                                     Only has effect if $route is a string.
      * @return self
      */
-    public function add(string $title, string $route = '', array $params = [])
+    public function add(string $title, $route = '', array $params = [])
     {
-        $route = !empty($params)
-            ? trim($route, '/ ').'&'.http_build_query($params)
-            : trim($route, '/ ');
+        if (!is_string($route) && !$route instanceof UriInterface) {
+            throw new \InvalidArgumentException(sprintf(
+                'Route should be either a string or an implementation of UriInterface. Got %s',
+                var_export($route, true)
+            ));
+        }
 
-        $this->items[$title] = !empty($route)? $this->baseURL . $route : '';
+        // backward compatible
+        if (is_string($route)) {
+            $route = !empty($params)
+                ? trim($route, '/ ').'&'.http_build_query($params)
+                : trim($route, '/ ');
+            $this->items[$title] = !empty($route)? $this->baseURL . $route : '';
+        } else {
+            // Do not support the query parameter at all because
+            // UriInterface should have that covered.
+            $this->items[$title] = $route;
+        }
 
         return $this;
     }

--- a/src/View/Page.php
+++ b/src/View/Page.php
@@ -37,9 +37,33 @@ class Page extends View
      * After constructing these class properties are publicly read-only.
      */
     protected $title = '';
+
+    /**
+     * Address of the page.
+     *
+     * @var string
+     */
     protected $address = '';
+
+    /**
+     * Action of the page
+     *
+     * @var Action
+     */
     protected $action;
+
+    /**
+     * Module that the page belongs to.
+     *
+     * @var Module
+     */
     protected $module;
+
+    /**
+     * Theme to render the page with.
+     *
+     * @var Theme
+     */
     protected $theme;
 
     /**
@@ -47,10 +71,35 @@ class Page extends View
      * and will be output at the end during template rendering.
      */
     protected $content = [];
+
+    /**
+     * Stylesheet asset.
+     *
+     * @var AssetBundle
+     */
     protected $stylesheets;
+
+    /**
+     * Stylesheet asset.
+     *
+     * @var AssetBundle
+     */
     protected $scripts;
+
+    /**
+     * Breadcrumb for the page.
+     *
+     * @var Breadcrumbs
+     */
     protected $breadcrumbs;
+
+    /**
+     * Return message, if any.
+     *
+     * @var ReturnMessage
+     */
     protected $return;
+
     protected $alerts = ['error' => [], 'warning' => [], 'success' => [], 'message' => []];
     protected $extra = ['head' => [], 'foot' => [], 'sidebar' => []];
 
@@ -62,7 +111,7 @@ class Page extends View
     public function __construct(Environment $templateEngine = null, array $params = [])
     {
         parent::__construct($templateEngine);
-        
+
         $this->breadcrumbs = new Breadcrumbs();
         $this->stylesheets = new AssetBundle();
         $this->scripts = new AssetBundle();
@@ -305,7 +354,7 @@ class Page extends View
             ? $this->extra[$context]
             : $this->extra;
     }
-    
+
     /**
      * Builds an array of page data to be passed to the template engine.
      *
@@ -318,7 +367,7 @@ class Page extends View
         // Eg: more than one on a non-module page, more than two on a module-page.
         $breadcrumbs = $this->breadcrumbs->getItems();
         $displayTrail = ((empty($this['isLoggedIn']) || empty($this->getModule())) && count($breadcrumbs) > 1) || (!empty($this->getModule()) && count($breadcrumbs) > 2);
-        
+
         return [
             'title'        => $this->getTitle(),
             'breadcrumbs'  => $displayTrail ? $breadcrumbs : [],

--- a/tests/unit/Gibbon/UrlTest.php
+++ b/tests/unit/Gibbon/UrlTest.php
@@ -91,6 +91,11 @@ class UrlTest extends TestCase
         $this->assertEquals('/some/path/index.php?' . http_build_query([
             'q' => '/modules/My Module/some_action.php',
         ]), (string) $url);
+
+        $url = Url::fromModuleRoute('My Module');
+        $this->assertEquals('/some/path/index.php?' . http_build_query([
+            'q' => '/modules/My Module/',
+        ]), (string) $url);
     }
 
     /**


### PR DESCRIPTION
This PR refactors the Behaviour Letters settings and behaviour_letters.php CLI script to use the Email Templates functionality, allowing more flexibility for creating behaviour letters, and more variables that can be used in them. The PR also renames the existing settings to specifically relate to Negative behaviour records, as a following PR will add the option to use Behaviour Letters functionality for positive records as well.

**Motivation and Context**
The current text box does not allow enough options for customizing the email letters send to parents.

**How Has This Been Tested?**
Locally.

**Screenshots**
<img width="968" alt="Screenshot 2021-10-20 at 8 32 58 PM" src="https://user-images.githubusercontent.com/897700/138095500-f1f31874-bbeb-4f45-813b-3b8a16b4c5a3.png">
<img width="995" alt="Screenshot 2021-10-20 at 8 33 09 PM" src="https://user-images.githubusercontent.com/897700/138095532-dabae4db-191c-43bf-8da6-785c2ca2ba00.png">
